### PR TITLE
Recipe for OCaml v4.02.0 (note licence terms)

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 ./configure -prefix $PREFIX
 make world.opt
-make -C testsuite all
+LINKFLAGS="" make -C testsuite all
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
+set -euo pipefail
 ./configure -prefix $PREFIX
 make world.opt
-make tests
+make -C testsuite all
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "ocaml" %}
-{% set version = "4.06.1" %}
-{% set sha256 = "0c38c6f531103e87fab1c218a7e76287d7cb4d7ee4dea64e7f85952af3b1b50e" %}
+{% set version = "4.02.0" %}
+{% set sha256 = "dbbcbd72a29a51206677a606ea09dfec83ae25cbbf52dee90306bc04812cd034" %}
 
 {% set version_major   = version.split(".")[0] %}
 {% set version_minor   = version.split(".")[1] %}
@@ -25,10 +25,13 @@ requirements:
 test:
   commands:
     - ocaml -version
+    - ocamlbuild -version
     - ocamlc -version
     - ocamlcmt -help
     - ocamlcp -version
+    - ocamldebug -version
     - ocamldep -version
+    - ocamldoc -version
     - ocamllex -version
     - ocamlmklib -version
     - ocamlmktop -version
@@ -43,8 +46,7 @@ test:
 
 about:
   home: https://ocaml.org/
-  license: LGPL-2.1
-  license_family: LGPL
+  license: QPL-1.0 (compiler, with change to choice of law), LGPL-2 (library)
   license_file: LICENSE
   summary: 'Objective Caml (OCaml) is an implementation of the ML language.'
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ test:
     - ocamlbuild -version
     - ocamlc -version
     - ocamlcp -version
-    - ocamldebug -version
     - ocamldep -version
     - ocamldoc -version
     - ocamllex -version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,8 +33,6 @@ test:
     - ocamlmklib -version
     - ocamlmktop -version
     - ocamlobjinfo -help
-    - ocamlobjinfo.byte -help
-    - ocamlobjinfo.opt -help
     - ocamlopt -version
     - ocamloptp -version
     - ocamlprof -version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ test:
     - ocamlc -version
     - ocamlcp -version
     - ocamldep -version
-    - ocamldoc -version
     - ocamllex -version
     - ocamlmklib -version
     - ocamlmktop -version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ test:
     - ocaml -version
     - ocamlbuild -version
     - ocamlc -version
-    - ocamlcmt -help
     - ocamlcp -version
     - ocamldebug -version
     - ocamldep -version


### PR DESCRIPTION
The licensing changed from OCaml v4.03 onwards, along with splitting out bits like ocamlbuild into its own release.