### PR TITLE
pin stricter as even patch versions might change abi

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,10 +15,10 @@ source:
     - prefix_fix.diff
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
-    - {{ pin_subpackage("ocaml") }}
+    - {{ pin_subpackage("ocaml", max_pin="x.x.x") }}
 
 requirements:
   build:


### PR DESCRIPTION
for eg: 4.11.1 -> 4.11.2 upgrade resulted in
"make inconsistent assumptions over implementation" in ocaml-zarith

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
