### PR TITLE
add more validation to tests - check output, not exit code

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - prefix_fix.diff
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage("ocaml", max_pin="x.x.x") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - prefix_fix.diff
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage("ocaml", max_pin="x.x.x") }}
@@ -33,24 +33,24 @@ requirements:
 
 test:
   commands:
-    - ocaml -version
-    - ocamlc -version
-    - ocamlcmt -help
-    - ocamlcp -version
-    - ocamldoc -version
-    - ocamldebug -version
-    - ocamldep -version
-    - ocamllex -version
-    - ocamlmklib -version
-    - ocamlmktop -version
-    - ocamlobjinfo -help
-    - ocamlobjinfo.byte -help
-    - ocamlobjinfo.opt -help
-    - ocamlopt -version
-    - ocamloptp -version
-    - ocamlprof -version
-    - ocamlrun -version
-    - ocamlyacc -version
+    - ocaml -version | grep {{ version }}
+    - ocamlc -version| grep {{ version }}
+    - ocamlcmt -help | grep FILE
+    - ocamlcp -version | grep {{ version }}
+    - ocamldoc -version | grep {{ version }}
+    - ocamldebug -version | grep {{ version }}
+    - ocamldep -version | grep {{ version }}
+    - ocamllex -version | grep {{ version }}
+    - ocamlmklib -version | grep {{ version }}
+    - ocamlmktop -version | grep {{ version }}
+    - ocamlobjinfo -help | grep FILES
+    - ocamlobjinfo.byte -help | grep FILES
+    - ocamlobjinfo.opt -help | grep FILES
+    - ocamlopt -version | grep {{ version }}
+    - ocamloptp -version | grep {{ version }}
+    - ocamlprof -version | grep {{ version }}
+    - ocamlrun -version | grep {{ version }}
+    - ocamlyacc -version | grep {{ version }}
 
 about:
   home: https://ocaml.org/


### PR DESCRIPTION
observed that whilst attempting an ocaml-5.0 build, the current tests pass but some binaries don't work and terminate quietly.
This PR changes the tests to check output of binaries is as expected.


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
