### PR TITLE
Update meta.yaml: bump version to trigger rebuild with gcc-14

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - prefix_fix.diff
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage("ocaml", max_pin="x.x.x") }}


### PR DESCRIPTION
* ocaml 4.14.2 is build with gcc 13, this is causing opam feedstock to not be able to resolve and start to build a new opam.
* bumping the build number here, and follow with a smith rerender, will get us over this block.
